### PR TITLE
Add flags to ignore organisation secrets and to wait for completion

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System;
 
 namespace SecretsMigrator
 {
@@ -39,6 +40,10 @@ namespace SecretsMigrator
             {
                 IsRequired = true
             };
+            var ignoreOrgSecrets = new Option("--ignore-org-secrets")
+            {
+                IsRequired = false
+            };
             var verbose = new Option("--verbose")
             {
                 IsRequired = false
@@ -50,14 +55,15 @@ namespace SecretsMigrator
             root.AddOption(targetRepo);
             root.AddOption(sourcePat);
             root.AddOption(targetPat);
+            root.AddOption(ignoreOrgSecrets);
             root.AddOption(verbose);
 
-            root.Handler = CommandHandler.Create<string, string, string, string, string, string, bool>(Invoke);
+            root.Handler = CommandHandler.Create<string, string, string, string, string, string, bool, bool>(Invoke);
 
             await root.InvokeAsync(args);
         }
 
-        public static async Task Invoke(string sourceOrg, string sourceRepo, string targetOrg, string targetRepo, string sourcePat, string targetPat, bool verbose = false)
+        public static async Task Invoke(string sourceOrg, string sourceRepo, string targetOrg, string targetRepo, string sourcePat, string targetPat, bool ignoreOrgSecrets = false, bool verbose = false)
         {
             _log.Verbose = verbose;
 
@@ -67,14 +73,16 @@ namespace SecretsMigrator
             _log.LogInformation($"TARGET ORG: {targetOrg}");
             _log.LogInformation($"TARGET REPO: {targetRepo}");
 
-            var branchName = "migrate-secrets";
-            var workflow = GenerateWorkflow(targetOrg, targetRepo, branchName);
+            var id = (new Random().Next(1000, 9999)).ToString();
+            var branchName = $"migrate-secrets-{id}";
+            var workflow = GenerateWorkflow(sourceOrg, sourceRepo, targetOrg, targetRepo, branchName, ignoreOrgSecrets);
 
             var githubClient = new GithubClient(_log, sourcePat);
             var githubApi = new GithubApi(githubClient, "https://api.github.com");
 
             var (publicKey, publicKeyId) = await githubApi.GetRepoPublicKey(sourceOrg, sourceRepo);
-            await githubApi.CreateRepoSecret(sourceOrg, sourceRepo, publicKey, publicKeyId, "SECRETS_MIGRATOR_PAT", targetPat);
+            await githubApi.CreateRepoSecret(sourceOrg, sourceRepo, publicKey, publicKeyId, "SECRETS_MIGRATOR_TARGET_PAT", targetPat);
+            await githubApi.CreateRepoSecret(sourceOrg, sourceRepo, publicKey, publicKeyId, "SECRETS_MIGRATOR_SOURCE_PAT", sourcePat);
 
             var defaultBranch = await githubApi.GetDefaultBranch(sourceOrg, sourceRepo);
             var masterCommitSha = await githubApi.GetCommitSha(sourceOrg, sourceRepo, defaultBranch);
@@ -85,7 +93,7 @@ namespace SecretsMigrator
             _log.LogSuccess($"Secrets migration in progress. Check on status at https://github.com/{sourceOrg}/{sourceRepo}/actions");
         }
 
-        private static string GenerateWorkflow(string targetOrg, string targetRepo, string branchName)
+        private static string GenerateWorkflow(string sourceOrg, string sourceRepo, string targetOrg, string targetRepo, string branchName, bool ignoreOrgSecrets = false)
         {
             var result = $@"
 name: move-secrets
@@ -106,16 +114,24 @@ jobs:
           [System.Reflection.Assembly]::LoadFrom($sodiumPath)
 
           $targetPat = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("":$($env:TARGET_PAT)""))
+          $sourcePat = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("":$($env:SOURCE_PAT)""))
           $publicKeyResponse = Invoke-RestMethod -Uri ""https://api.github.com/repos/$env:TARGET_ORG/$env:TARGET_REPO/actions/secrets/public-key"" -Method ""GET"" -Headers @{{ Authorization = ""Basic $targetPat"" }}
           $publicKey = [Convert]::FromBase64String($publicKeyResponse.key)
           $publicKeyId = $publicKeyResponse.key_id
-              
+
           $secrets = $env:REPO_SECRETS | ConvertFrom-Json
+          $ignoreSecrets = @(""github_token"", ""SECRETS_MIGRATOR_SOURCE_PAT"", ""SECRETS_MIGRATOR_TARGET_PAT"")
+
+          if ([System.Convert]::ToBoolean($env:IGNORE_ORG_SECRETS)) {{
+            $orgSecretsResponse = Invoke-RestMethod -Uri ""https://api.github.com/repos/$env:SOURCE_ORG/$env:SOURCE_REPO/actions/organization-secrets"" -Method ""GET"" -Headers @{{ Authorization = ""Basic $sourcePat"" }}
+            $ignoreSecrets += $orgSecretsResponse.secrets.name
+          }}
+ 
           $secrets | Get-Member -MemberType NoteProperty | ForEach-Object {{
             $secretName = $_.Name
             $secretValue = $secrets.""$secretName""
      
-            if ($secretName -ne ""github_token"" -and $secretName -ne ""SECRETS_MIGRATOR_PAT"") {{
+            if ($secretName -notin $ignoreSecrets) {{
               Write-Output ""Migrating Secret: $secretName""
               $secretBytes = [Text.Encoding]::UTF8.GetBytes($secretValue)
               $sealedPublicKeyBox = [Sodium.SealedPublicKeyBox]::Create($secretBytes, $publicKey)
@@ -135,13 +151,18 @@ jobs:
           }}
 
           Write-Output ""Cleaning up...""
-          Invoke-RestMethod -Uri ""https://api.github.com/repos/${{{{ github.repository }}}}/git/${{{{ github.ref }}}}"" -Method ""DELETE"" -Headers @{{ Authorization = ""Basic $targetPat"" }}
-          Invoke-RestMethod -Uri ""https://api.github.com/repos/${{{{ github.repository }}}}/actions/secrets/SECRETS_MIGRATOR_PAT"" -Method ""DELETE"" -Headers @{{ Authorization = ""Basic $targetPat"" }}
+          Invoke-RestMethod -Uri ""https://api.github.com/repos/${{{{ github.repository }}}}/git/${{{{ github.ref }}}}"" -Method ""DELETE"" -Headers @{{ Authorization = ""Basic $sourcePat"" }}
+          Invoke-RestMethod -Uri ""https://api.github.com/repos/${{{{ github.repository }}}}/actions/secrets/SECRETS_MIGRATOR_TARGET_PAT"" -Method ""DELETE"" -Headers @{{ Authorization = ""Basic $sourcePat"" }}
+          Invoke-RestMethod -Uri ""https://api.github.com/repos/${{{{ github.repository }}}}/actions/secrets/SECRETS_MIGRATOR_SOURCE_PAT"" -Method ""DELETE"" -Headers @{{ Authorization = ""Basic $sourcePat"" }}
         env:
           REPO_SECRETS: ${{{{ toJSON(secrets) }}}}
-          TARGET_PAT: ${{{{ secrets.SECRETS_MIGRATOR_PAT }}}}
+          TARGET_PAT: ${{{{ secrets.SECRETS_MIGRATOR_TARGET_PAT }}}}
+          SOURCE_PAT: ${{{{ secrets.SECRETS_MIGRATOR_SOURCE_PAT }}}}
           TARGET_ORG: '{targetOrg}'
           TARGET_REPO: '{targetRepo}'
+          SOURCE_ORG: '{sourceOrg}'
+          SOURCE_REPO: '{sourceRepo}'
+          IGNORE_ORG_SECRETS: '{ignoreOrgSecrets}'
         shell: pwsh
 ";
 

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SecretsMigrator": {
       "commandName": "Project",
-      "commandLineArgs": "migrate-secrets --source-org dylan-smith --source-repo secrets-testing --target-org dylan-smith --target-repo secrets-target --source-pat \"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\" --target-pat \"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\""
+      "commandLineArgs": "migrate-secrets --source-org dylan-smith --source-repo secrets-testing --target-org dylan-smith --target-repo secrets-target --source-pat \"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\" --target-pat \"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\" --ignore-org-secrets"
     }
   }
 }

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SecretsMigrator": {
       "commandName": "Project",
-      "commandLineArgs": "migrate-secrets --source-org dylan-smith --source-repo secrets-testing --target-org dylan-smith --target-repo secrets-target --source-pat \"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\" --target-pat \"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\" --ignore-org-secrets"
+      "commandLineArgs": "migrate-secrets --source-org dylan-smith --source-repo secrets-testing --target-org dylan-smith --target-repo secrets-target --source-pat \"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\" --target-pat \"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\" --ignore-org-secrets --wait-for-completion"
     }
   }
 }

--- a/src/SecretsMigrator.csproj
+++ b/src/SecretsMigrator.csproj
@@ -1,12 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
@@ -15,5 +14,4 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
   </ItemGroup>
-
 </Project>

--- a/src/SecretsMigrator.csproj
+++ b/src/SecretsMigrator.csproj
@@ -1,11 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
@@ -14,4 +15,5 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Given this POC repository is currently GH's recommended best existing solution for migrating secrets, I'm hoping to extend the current functionality to serve our use case better.

Added two flags:
- ignore organisation secrets: this is creating (incorrect and) duplicate secrets during migrations in many use cases
- wait for completion: wait for the job to finish to integrate secret migration in extended migration workflows

I also added a slug to the branch names to reduce branch naming conflict.